### PR TITLE
Add Spreadpaper as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ This is a list to some of my open source projects 🤓🍕
 
 ## Standalone projects
 
+### SpreadPaper
+![GitHub License](https://img.shields.io/github/license/spreadpaper/spreadpaper)
+
+**SpreadPaper** is a native macOS utility designed to spread a single high-resolution wallpaper seamlessly across multiple monitors. It enables users to display one panoramic image across 2, 3, or more connected displays with an intuitive drag-and-drop interface, live preview, zoom controls, and preset management.
+
+- [Visit website](https://spreadpaper.com)
+- [Repository](https://github.com/spreadpaper/spreadpaper)
+
 ### Curaçao Election 2025
 ![GitHub License](https://img.shields.io/github/license/rvanbaalen/curacao-election-2025)
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is a list to some of my open source projects 🤓🍕
 
 **SpreadPaper** is a native macOS utility designed to spread a single high-resolution wallpaper seamlessly across multiple monitors. It enables users to display one panoramic image across 2, 3, or more connected displays with an intuitive drag-and-drop interface, live preview, zoom controls, and preset management.
 
-- [Visit website](https://spreadpaper.com)
+- [Visit website](https://spreadpaper.github.io/spreadpaper)
 - [Repository](https://github.com/spreadpaper/spreadpaper)
 
 ### Curaçao Election 2025

--- a/index.html
+++ b/index.html
@@ -63,6 +63,24 @@
 
             <div class="grid md:grid-cols-2 gap-8">
 
+                <!-- SpreadPaper -->
+                <div class="bg-white rounded-lg shadow-md overflow-hidden transition hover:shadow-lg">
+                    <div class="p-6 flex flex-col h-full">
+                        <div class="flex items-center justify-between mb-4">
+                            <h3 class="text-2xl font-bold text-sky-700">SpreadPaper</h3>
+                            <div class="flex space-x-1">
+                                <img src="https://img.shields.io/github/license/spreadpaper/spreadpaper" alt="GitHub License" class="h-6">
+                            </div>
+                        </div>
+                        <p class="mb-6 flex-grow">
+                            <strong>SpreadPaper</strong> is a native macOS utility designed to spread a single high-resolution wallpaper seamlessly across multiple monitors. Features an intuitive drag-and-drop interface with live preview, zoom controls, and preset management.
+                        </p>
+                        <div class="flex space-x-4 mt-auto">
+                            <a href="https://spreadpaper.com" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition">Visit Website</a>
+                            <a href="https://github.com/spreadpaper/spreadpaper" class="px-4 py-2 bg-gray-200 text-gray-800 rounded hover:bg-gray-300 transition">Repository</a>
+                        </div>
+                    </div>
+                </div>
 
                 <!-- ValidForm Builder -->
                 <div class="bg-white rounded-lg shadow-md overflow-hidden transition hover:shadow-lg">

--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
                             <strong>SpreadPaper</strong> is a native macOS utility designed to spread a single high-resolution wallpaper seamlessly across multiple monitors. Features an intuitive drag-and-drop interface with live preview, zoom controls, and preset management.
                         </p>
                         <div class="flex space-x-4 mt-auto">
-                            <a href="https://spreadpaper.com" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition">Visit Website</a>
+                            <a href="https://spreadpaper.github.io/spreadpaper" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition">Visit Website</a>
                             <a href="https://github.com/spreadpaper/spreadpaper" class="px-4 py-2 bg-gray-200 text-gray-800 rounded hover:bg-gray-300 transition">Repository</a>
                         </div>
                     </div>


### PR DESCRIPTION
Add SpreadPaper, a native macOS utility for spreading wallpapers across multiple monitors, to the standalone projects section.